### PR TITLE
Quote -OutputDirectory option

### DIFF
--- a/OnBuild.PackageAssemblyForNuget/OnBuild.PackageAssemblyForNuget.targets
+++ b/OnBuild.PackageAssemblyForNuget/OnBuild.PackageAssemblyForNuget.targets
@@ -38,7 +38,7 @@
     <Error Condition="@(NuSpec)==''" Text="Nuspec file created please edit it" />
     <Exec
         Condition="@(NuSpec)!=''"
-        Command="&quot;$(nugetLatest)&quot; pack $(MSBuildProjectFile) -OutputDirectory $(TargetDir) "
+        Command="&quot;$(nugetLatest)&quot; pack $(MSBuildProjectFile) -OutputDirectory &quot;$(TargetDir).&quot; "
         CustomWarningRegularExpression=".*(Issue:|Description:).*"
         LogStandardErrorAsError="true"  />
   </Target>


### PR DESCRIPTION
If $(TargetDir) path includes space char then NuGet pack was failed.
Then quote $(TargetDir) by `&quot;`.
