### PR TITLE
Enabled configuration option

### DIFF
--- a/OnBuild.PackageAssemblyForNuget/OnBuild.PackageAssemblyForNuget.targets
+++ b/OnBuild.PackageAssemblyForNuget/OnBuild.PackageAssemblyForNuget.targets
@@ -50,7 +50,7 @@
     <Error Condition="@(NuSpec)==''" Text="Nuspec file created please edit it" />
     <Exec
         Condition="@(NuSpec)!=''"
-        Command="&quot;$(nugetLatest)&quot; pack $(MSBuildProjectFile) -OutputDirectory &quot;$(TargetDir).&quot; "
+        Command="&quot;$(nugetLatest)&quot; pack $(MSBuildProjectFile) -Properties &quot;Configuration=$(Configuration);Platform=$(Platform)&quot; -OutputDirectory &quot;$(TargetDir).&quot; "
         CustomWarningRegularExpression=".*(Issue:|Description:).*"
         LogStandardErrorAsError="true"  />
   </Target>


### PR DESCRIPTION
ビルド構成が`Release`のときにも`bin\Debug`フォルダーを参照しているようでしたので修正しました。
フォルダーを削除した状態でビルドすると再現できます。

この問題は`Command="$(BuildCommand)"`でも解決します。
`$(BuildCommand)`は`$(SolutionDir)\.nuget\NuGet.targets`で定義されています。
Testプロジェクトで下記を追加しましたがTestプロジェクトをうまく構成できず、`$(BuildCommand)`を断念しました。

``` xml
<Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
```
