### PR TITLE
MSBuild 14.0サポートを追加する

### DIFF
--- a/OnBuild.PackageAssemblyForNuget/OnBuild.PackageAssemblyForNuget.targets
+++ b/OnBuild.PackageAssemblyForNuget/OnBuild.PackageAssemblyForNuget.targets
@@ -7,6 +7,9 @@
   <PropertyGroup Condition="Exists('$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll')">
     <CodeTaskFactoryAssembly>$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll</CodeTaskFactoryAssembly>
   </PropertyGroup>
+  <PropertyGroup Condition="Exists('$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll')">
+    <CodeTaskFactoryAssembly>$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll</CodeTaskFactoryAssembly>
+  </PropertyGroup>
 
   <UsingTask
     TaskName="SelectLast"


### PR DESCRIPTION
VS2015のみインストールした環境でもOnBuild.PackageAssemblyForNugetが動作するため、MSBuild.exeの探索先パスにMSBuild 14.0のパスを追加する。

なお、VS2015で使用する場合、VS2013と違い`NuGet.CommandLine`もプロジェクト内の`packages.config`に以下のように書き込まれる。

``` xml
<packages>
  <package id="NuGet.CommandLine" version="2.8.0" targetFramework="net452" />
  <package id="OnBuild.PackageAssemblyForNuget" version="1.0.8" targetFramework="net452" developmentDependency="true" />
</packages>
```

`NuGet.CommandLine`には`developmentDependency="true"`がつかないため、手動で追加しないと、作成したパッケージに依存関係が残ってしまうことに注意が必要です。
